### PR TITLE
fix(a11y): add scope on table headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 .cache
 .DS_Store
 .sass-cache
+.idea
 source/images/qrencode.png
 build/
+config/current.yml

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -15,6 +15,11 @@
 		'%02d:%02d' % [time/60, time % 60]
 	end
 
+	def label_type(type)
+	    labels = { "misc" => "Divers", "workshop" => "Atelier", "talk" => "Conférence"}
+	    labels[type]
+    end
+
 	FROM = parse_time('10:00')
 	TO = parse_time('21:00')
 	STEP = parse_time('00:30')
@@ -46,7 +51,7 @@
 		end.collect { |l, es| { day: day, location: l, events: es } }
 	end.flatten 1
 %>
-
+<h1 class="planning__title">PSES 2019</h1>
 <ul class="legend">
 	<li>
 		<span class="talk">&nbsp;</span> Conférence
@@ -68,9 +73,15 @@
 	</li>
 </ul>
 <table class="timetable">
+  <caption class="timetable__caption">Planning de Pas Sage en Seine 2019</caption>
+  <col>
+  <colgroup span="2"></colgroup>
+  <colgroup span="2"></colgroup>
+  <colgroup span="2"></colgroup>
+  <colgroup span="2"></colgroup>
 	<thead>
 	<tr>
-		<th rowspan="2">
+		<td rowspan="2">
 			<% link_to 'index.ics' do %>
 				<svg version="1.1" xmlns="http://www.w3.org/2000/svg"
 					 x="0px" y="0px"
@@ -104,15 +115,14 @@
 		<% planning.each do |day, locations| %>
 			<%=
 				n = locations.size
-				attributes = n == 1 ? nil : { colspan: n }
-				content_tag(:th, attributes) { I18n.l day, format: '%A %d %B' }
+				content_tag(:th, :colspan => (n if n >= 1), :scope => 'colgroup') { I18n.l day, format: '%A %d %B' }
 			%>
 		<% end %>
 	</tr>
 	<tr>
 		<% planning.each do |day, locations|
 			locations.each do |location, _|      %>
-			<th>
+			<th scope='col'>
 				<%= case location.to_sym
 					when :cinema
 						'Salle cinéma'
@@ -134,8 +144,8 @@
 		(FROM...TO).step(STEP).each do |time| %>
 		<tr>
 			<%=
-				clazz = :hidden unless time % 60 == 0
-				content_tag :th, to_time(time), class: clazz
+				hiddenClass = "visually-hidden" unless time % 60 == 0
+				content_tag(:th, content_tag(:span, to_time(time), class: hiddenClass), :scope => 'row')
 			%>
 			<% columns.each do |column|
 				events = column[:events]
@@ -148,10 +158,13 @@
 					%>
 				<% unless event[:placeholder]
 					   content_tag :td, **attributes do %>
-						<% content_tag :div, class: "event #{event[:type]}" do %>
+						<% content_tag :article, class: "event #{event[:type]}" do %>
 							<div class="time">
 								<%= to_time from %> - <%= to_time to %>
 							</div>
+						  <div class="type">
+                  <%= label_type(event[:type]) %>
+              </div>
 							<div class="title">
 								<%= event[:title] %>
 							</div>
@@ -178,11 +191,11 @@
 </table>
 
 <div class="modal hidden">
-	<div class="header">
+	<header class="header">
 		<div class="time"></div>
 		<div class="title"></div>
 		<div class="author"></div>
-	</div>
+	</header>
 	<div class="body"></div>
 	<div class="close"></div>
 	<div class="cover"></div>

--- a/source/javascripts/site.js.coffee
+++ b/source/javascripts/site.js.coffee
@@ -1,6 +1,6 @@
 class TimeTable
 	constructor: (@element, @modal) ->
-		events = @element.querySelectorAll 'tbody td > div'
+		events = @element.querySelectorAll 'tbody td > .event'
 		for event in events
 			# JS scoping hell…
 			event.addEventListener 'click', ((_this, _event) ->

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="x-ua-compatible" content="ie=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>Programme PSES</title>
+	<title>Programme PSES 2019</title>
 	<%= favicon_tag 'logo.ico' %>
 	<%= stylesheet_link_tag 'site' %>
 	<%= javascript_include_tag 'site' %>

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1,24 +1,10 @@
-* {
+*,
+*::before,
+*::after {
 	box-sizing: border-box;
 }
 
-$line-height: 150px;
-
 $background: #212121;
-//$background: #000;
-
-//$event-talk: #3F51B5;
-//$event-workshop: #f44336;
-//$event-concert: #4CAF50;
-//$event-round-table: #FFC107;
-//$event-misc: #673AB7;
-
-//$event-talk: #2962FF;
-//$event-workshop: #DD2C00;
-//$event-concert: #00C853;
-//$event-round-table: #FF6D00;
-//$event-misc: #6200EA;
-
 $event-talk: #2980b9;
 $event-workshop: #c0392b;
 $event-concert: #27ae60;
@@ -38,8 +24,43 @@ $event-young: #EF6C00;
 	transition: $args;
 }
 
+.visually-hidden {
+	/* Remove the item from normal flow */
+	position: absolute;
+	/* Workaround for falsely pronounced, smushed text */
+	white-space: nowrap;
+	/* Set it to the smallest possible size (some screen readers ignore elements with zero height and width) */
+	width: 1px;
+	height: 1px;
+	/* Hide overflowing content after resizing */
+	overflow: hidden;
+	/* Reset any property that may change the elements size */
+	border: 0;
+	padding: 0;
+	/* Clipping defines what part of an element should be displayed. */
+	/* Deprecated clip property for older browsers */
+	clip: rect(0 0 0 0);
+	/* clip-path for newer browsers. inset(50%) defines an inset rectangle that makes the content disappear.  */
+	clip-path: inset(50%);
+	/* It seems like at the moment nobody is quite sure why margin: -1px is there. On top of that it seems to cause issues (see: https://github.com/h5bp/html5-boilerplate/issues/1985). */
+	margin: -1px;
+}
+
+html {
+	font-size: 60.5%;
+}
+
 body {
-	font-size: 10pt;
+	font-size: 1.6rem;
+	font-family: Helvetica, Arial, sans-serif;
+}
+
+.planning__title {
+	font-family: Georgia, serif;
+}
+
+.timetable__caption {
+	margin-bottom: 12px;
 }
 
 table.timetable {
@@ -72,7 +93,7 @@ table.timetable {
 
 	tbody {
 		th, td {
-			height: 150px;
+			height: 210px;
 			border-top: none;
 			border-bottom: none;
 		}
@@ -93,7 +114,7 @@ table.timetable {
 
 			vertical-align: top;
 
-			& > div {
+			& > .event {
 				//Fuck off, Firefox
 				//width: 100%;
 				//height: 100%;
@@ -137,6 +158,11 @@ ul.legend {
 
 .title {
 	font-weight: bold;
+	margin-bottom: 8px;
+}
+
+.type {
+	margin-bottom: 8px;
 }
 
 .author {


### PR DESCRIPTION
- Help screenreader understand the direction of the header (is it for a row or a column?)
- Display the type of event (talk...): a color isn't enough to pass an information
- Add the year in <title> so there is no doubt about the edition
- Add a legend to the table